### PR TITLE
add dependabot to avoid PRs like #95

### DIFF
--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "yarn" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: "yarn" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "cargo" # See documentation for possible values
+    directory: "/src-tauri" # Location of package manifests
     schedule:
       interval: "weekly"

--- a/.github/.dependabot.yml
+++ b/.github/.dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
-  - package-ecosystem: "cargo" # See documentation for possible values
+
+# cargo 
+- package-ecosystem: "cargo" # See documentation for possible values
     directory: "/src-tauri" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+# npm
+- package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
#### **Description**
updating packages avoids the security risks that each circular dependency holds. Adding dependabot also makes it easier to make sure that the platform is well up-to date even with passive development, overall a good practice to have it.


#### **Checklist**

- [x] Are the features of this PR completed?
- [x] Is the PR following the guidelines?
