### PR TITLE
Addressed a problem with loading banners + some banner bug fixes

### DIFF
--- a/src/components/find-games.vue
+++ b/src/components/find-games.vue
@@ -38,7 +38,7 @@ class Elements {
       dirPath: GAME_BANNERS_BASE_PATH,
     });
     const img = dirs.find(
-      (x) => x === `${sha256(game.DisplayName.replaceAll(" ", "_"))}.png`
+      (x) => x === `${sha256(game.DisplayName.replaceAll(" ", "_").replace(/[\u{0080}-\u{FFFF}]/gu,""))}.png`
     );
     if (img) {
       banner = img
@@ -474,7 +474,10 @@ export default {
       return games;
     },
     async loadGames(id, data, stored) {
-      const games = data ?? (await this.getInstalledGames());
+      const games =
+        (await this.getInstalledGames()).filter(
+          (x) => !require("./others/blacklist.json")[0].includes(x.GameID)
+        );
       const list = document.getElementById(id);
 
       (await this.filterAndSort(games, id, list, stored))
@@ -484,6 +487,7 @@ export default {
         );
       if (games.length > 0 && id === "allGamesList") {
         setGames(games, "all-games");
+        require("./modules/banners").getBanners(await Promise.all(games));
       }
 
       if (!data) {

--- a/src/components/modules/banners.js
+++ b/src/components/modules/banners.js
@@ -8,14 +8,14 @@ async function getBanners(games) {
   games = games.filter((x) => !["CustomGame"].includes(x.LauncherName));
   const bannerBasePath = (await path.appDir()) + "cache/games/banners";
   const readBanners = await invoke('read_dir', { dirPath: bannerBasePath })
-
+  
   let alreadyProcessed = false;
   let existingProcessed = 0;
 
   for (let i = 0; i < games.length; i++) {
     if (
       readBanners.includes(
-        `${sha256(games[i].DisplayName.replaceAll(" ", "_"))}.png`
+        `${sha256(games[i].DisplayName.replaceAll(" ", "_").replace(/[\u{0080}-\u{FFFF}]/gu,""))}.png`
       )
     ) {
       existingProcessed++;
@@ -49,7 +49,7 @@ async function getBanners(games) {
             return "https://logos-world.net/wp-content/uploads/2021/03/FiveM-Symbol.png";
           }
           case "Lunar": {
-            return "https://www.lunarclient.com/assets/img/default-twitter-icon.webp";
+            return "https://pbs.twimg.com/profile_images/1608698913476812801/uLTLhANK_400x400.jpg";
           }
           case "Lutris": {
             if (
@@ -121,7 +121,7 @@ async function getBanners(games) {
       })()
     );
   }
-
+  
   cacheBanners(
     games,
     arr.filter((x) => x)
@@ -130,6 +130,7 @@ async function getBanners(games) {
 }
 
 async function cacheBanners(data, res) {
+
   const bannerBasePath = (await path.appDir()) + "cache/games/banners";
 
   if (data?.length === 0) {
@@ -159,15 +160,19 @@ async function cacheBanners(data, res) {
           await invoke("write_binary_file", {
             filePath:
               bannerBasePath +
-              `/${sha256(data[i].DisplayName.replaceAll(" ", "_"))}.png`,
+              `/${sha256(data[i].DisplayName.replaceAll(" ", "_").replace(/[\u{0080}-\u{FFFF}]/gu,""))}.png`,
             fileContent: response.data,
           });
           const banner = document.getElementById(`game-div-${data[i].DisplayName.replaceAll(" ", "_")}`)?.firstElementChild;
+          console.log(tauri.convertFileSrc(
+            bannerBasePath +
+            `/${sha256(data[i].DisplayName.replaceAll(" ", "_").replace(/[\u{0080}-\u{FFFF}]/gu,""))}.png`
+          ))
           banner?.setAttribute(
             "src",
             tauri.convertFileSrc(
               bannerBasePath +
-              `/${sha256(data[i].DisplayName.replaceAll(" ", "_"))}.png`
+              `/${sha256(data[i].DisplayName.replaceAll(" ", "_").replace(/[\u{0080}-\u{FFFF}]/gu,""))}.png`
             )
           );
           banner.style = 'content: none;';


### PR DESCRIPTION
#### **Description**
The recent release, 0.6.2, lacks the getBanner function to load banners for games. Furthermore, I've improved the load banner functionality by filtering the blacklist before the banners start processing. Have a look at the commit for more explicit changes.

#### **Changes**
```diff
+ Added getBanners
= Changed old webp format lunar client with another jpg image
```

#### **Affected Operating System(s)**

Windows(8, 10, 11), Linux(Arch, Manjaro, etc.), MacOS

#### **Additional Information**
None


#### **Checklist**

- [x] Are the features of this PR completed?
- [x] Is the PR following the guidelines?
